### PR TITLE
Adding Queue mode and MQTT Features.  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+.vagrant

--- a/README.md
+++ b/README.md
@@ -9,9 +9,14 @@ The application provides a simple interface for gathering and reporting votes ab
 The application is built in a microservice style wrapping each service in a docker container
  that can be deployed and run in Mantl.  In its initial form the applicaiton has three services.
 
-1.  myhero/data - This service stores all the data about candidates and votes cast.
-2.  myhero/app - This service provides the basic logic layer for accessing and recording votes.
-3.  myhero/web - This is the main user interface for casting votes.
+1. myhero/data - This service stores all the data about candidates and votes cast.
+2. myhero/app - This service provides the basic logic layer for accessing and recording votes.
+3. myhero/web - This is the main user interface for casting votes.
+
+There is an optional deployment mode where votes are processed through an MQTT Server by being published by the myhero/app service, and processed by myhero/ernst service that subscribes to the queue.
+In this mode, these additional services are deployed.
+4. myhero/mosca - MQTT Server based on [Mosca](https://hub.docker.com/r/matteocollina/mosca/)
+5. myhero/ernst - Vote processing services
 
 All of the demo details here make use of the Mantl or Marathon APIs to build and manage applciations.  If you prefer to use the different GUIs to execute the demos, you can use the JSON files to find the details needed to configure manually.
 
@@ -39,7 +44,8 @@ In order to leverage this demonstration, you will need to have a Mantl cluster u
 
 Run `source myhero_setup` to enter and record the address, application domain, username, and password for your Mantl instance as non-persistent Environment Variables.  This means you will need to run this command everytime you open an new terminal session.
 
-## Install
+## Basic Deployment
+### Install
 
 Run `./myhero-install.sh` to deploy all three services (data, app, web) to your Mantl cluster.
 
@@ -47,9 +53,25 @@ After running the install it will take a 2-5 minutes for all three services to f
 
 You should be able to reach the web interface for the application at `http://myhero-web.YOUR-DOMAIN` where `YOUR-DOMAIN` refers to the wildcard domain configured for Traefik.
 
-## Uninstallation
+### Uninstallation
 
 Run `./myhero-uninstall.sh` to remove all three services from Marathon.
+
+## Advanced Optional Deployment Using MQTT Server and Queuing
+**IN DEVELOPMENT - MAY NOT BE READY FOR WIDE USAGE**
+
+### Install
+
+Run `./myhero-install-queue.sh` to deploy the standard three services (data, app, web) along with an MQTT Server (based on Mosca) and a vote processing service (ernst) to your Mantl cluster.
+
+After running the install it will take a 2-5 minutes for all three services to fully deploy and become "healthy".  You can monitor this in the Marathon Web GUI.
+
+You should be able to reach the web interface for the application at `http://myhero-web.YOUR-DOMAIN` where `YOUR-DOMAIN` refers to the wildcard domain configured for Traefik.
+
+### Uninstallation
+
+Run `./myhero-uninstall-queue.sh` to remove all services from Marathon.
+
 
 ## Basic Scaling Demo
 
@@ -91,17 +113,28 @@ A strength of Modern Applications are that you can interact with any of the serv
   * `curl -H "key: SecureApp" -X POST http://myhero-app.$MANTL_DOMAIN/vote/Batman`
 
 ## MyHero Service Code and Containers
-Code for the servers:
+Other services are:
 * Data - [hpreston/myhero_data](https://github.com/hpreston/myhero_data)
 * App - [hpreston/myhero_app](https://github.com/hpreston/myhero_app)
 * Web - [hpreston/myhero_web](https://github.com/hpreston/myhero_web)
+* Ernst - [hpreston/myhero_ernst](https://github.com/hpreston/myhero_ernst)
+  * Optional Service used along with an MQTT server when App is in "queue" mode
 * Spark Bot - [hpreston/myhero_spark](https://github.com/hpreston/myhero_spark)
+  * Optional Service that allows voting through IM/Chat with a Cisco Spark Bot
+* Tropo App - [hpreston/myhero_tropo](https://github.com/hpreston/myhero_tropo)
+  * Optional Service that allows voting through TXT/SMS messaging
+
 
 The docker containers are available at
 * Data - [hpreston/myhero_data](https://hub.docker.com/r/hpreston/myhero_data)
 * App - [hpreston/myhero_app](https://hub.docker.com/r/hpreston/myhero_app)
 * Web - [hpreston/myhero_web](https://hub.docker.com/r/hpreston/myhero_web)
+* Ernst - [hpreston/myhero_ernst](https://hub.docker.com/r/hpreston/myhero_ernst)
+  * Optional Service used along with an MQTT server when App is in "queue" mode
 * Spark Bot - [hpreston/myhero_spark](https://hub.docker.com/r/hpreston/myhero_spark)
+  * Optional Service that allows voting through IM/Chat with a Cisco Spark Bot
+* Tropo App - [hpreston/myhero_tropo](https://hub.docker.com/r/hpreston/myhero_tropo)
+  * Optional Service that allows voting through TXT/SMS messaging
 
 
 ## Other Mantl Demo Ideas

--- a/myhero-app.json
+++ b/myhero-app.json
@@ -2,7 +2,7 @@
     "container": {
         "type": "DOCKER",
         "docker": {
-            "image": "hpreston/myhero_app",
+            "image": "hpreston/myhero_app:latest",
             "forcePullImage": true,
             "network": "BRIDGE",
             "portMappings": [{

--- a/myhero-data.json
+++ b/myhero-data.json
@@ -2,7 +2,7 @@
     "container": {
         "type": "DOCKER",
         "docker": {
-            "image": "hpreston/myhero_data",
+            "image": "hpreston/myhero_data:latest",
             "forcePullImage": true,
             "network": "BRIDGE",
             "portMappings": [{

--- a/myhero-ernst.json
+++ b/myhero-ernst.json
@@ -1,0 +1,22 @@
+{
+    "container": {
+        "type": "DOCKER",
+        "docker": {
+            "image": "hpreston/myhero_ernst:latest",
+            "forcePullImage": true,
+            "network": "BRIDGE",
+            "portMappings": []
+        },
+        "forcePullImage": true
+    },
+    "healthChecks": [],
+    "id": "/myhero/ernst",
+    "instances": 1,
+    "cpus": 1,
+    "mem": 64,
+    "env": {
+        "myhero_data_server": "http://myhero-data",
+        "myhero_data_key": "SecureData",
+        "myhero_mqtt_server": "mosca-myhero.service.consul"
+    }
+}

--- a/myhero-install-queue.sh
+++ b/myhero-install-queue.sh
@@ -1,0 +1,54 @@
+#! /bin/bash
+
+[ -z "$MANTL_CONTROL" ] && echo "Please run 'source myhero_setup' to set Environment Variables" && exit 1;
+[ -z "$MANTL_USER" ] && echo "Please run 'source myhero_setup' to set Environment Variables" && exit 1;
+[ -z "$MANTL_PASSWORD" ] && echo "Please run 'source myhero_setup' to set Environment Variables" && exit 1;
+[ -z "$MANTL_DOMAIN" ] && echo "Please run 'source myhero_setup' to set Environment Variables" && exit 1;
+
+echo Deploying Data Service
+curl -k -X POST -u $MANTL_USER:$MANTL_PASSWORD https://$MANTL_CONTROL:8080/v2/apps \
+-H "Content-type: application/json" \
+-d @myhero-data.json
+echo ***************************************************
+echo
+
+echo Deploying Mosca
+curl -k -X POST -u $MANTL_USER:$MANTL_PASSWORD https://$MANTL_CONTROL:8080/v2/apps \
+-H "Content-type: application/json" \
+-d @myhero-mosca.json
+echo ***************************************************
+echo
+
+echo Deploying Ernst Service
+curl -k -X POST -u $MANTL_USER:$MANTL_PASSWORD https://$MANTL_CONTROL:8080/v2/apps \
+-H "Content-type: application/json" \
+-d @myhero-ernst.json
+curl -k -X PUT -u $MANTL_USER:$MANTL_PASSWORD https://$MANTL_CONTROL:8080/v2/apps/myhero/ernst?force=true \
+-H "Content-type: application/json" \
+-d "{\"env\": {\"myhero_data_server\": \"http://myhero-data.$MANTL_DOMAIN\", \"myhero_data_key\": \"SecureData\", \"myhero_mqtt_server\": \"mosca-myhero.service.consul\"}}"
+echo ***************************************************
+echo
+
+
+echo Deploying Application Service
+curl -k -X POST -u $MANTL_USER:$MANTL_PASSWORD https://$MANTL_CONTROL:8080/v2/apps \
+-H "Content-type: application/json" \
+-d @myhero-app.json
+curl -k -X PUT -u $MANTL_USER:$MANTL_PASSWORD https://$MANTL_CONTROL:8080/v2/apps/myhero/app?force=true \
+-H "Content-type: application/json" \
+-d "{\"env\": {\"myhero_data_server\": \"http://myhero-data.$MANTL_DOMAIN\", \"myhero_data_key\": \"SecureData\", \"myhero_app_key\": \"SecureApp\", \"myhero_mqtt_server\": \"mosca-myhero.service.consul\", \"myhero_app_mode\": \"queue\"}}"
+echo ***************************************************
+echo
+
+echo Deploying Web Service
+curl -k -X POST -u $MANTL_USER:$MANTL_PASSWORD https://$MANTL_CONTROL:8080/v2/apps \
+-H "Content-type: application/json" \
+-d @myhero-web.json
+curl -k -X PUT -u $MANTL_USER:$MANTL_PASSWORD https://$MANTL_CONTROL:8080/v2/apps/myhero/mq/web?force=true \
+-H "Content-type: application/json" \
+-d "{\"env\": {\"myhero_app_server\": \"http://myhero-app.$MANTL_DOMAIN\", \"myhero_app_key\": \"SecureApp\"}}"
+echo ***************************************************
+echo
+
+echo Deployed
+

--- a/myhero-mosca.json
+++ b/myhero-mosca.json
@@ -2,11 +2,11 @@
     "container": {
         "type": "DOCKER",
         "docker": {
-            "image": "hpreston/myhero_app:latest",
+            "image": "matteocollina/mosca:latest",
             "forcePullImage": true,
             "network": "BRIDGE",
             "portMappings": [{
-                "containerPort": 5000,
+                "containerPort": 1883,
                 "hostPort": 0
             }]
         },
@@ -16,13 +16,9 @@
         "protocol": "TCP",
         "portIndex": 0
     }],
-    "id": "/myhero/app",
-    "instances": 3,
-    "cpus": 0.5,
-    "mem": 32,
-    "env": {
-        "myhero_data_server": "http://myhero-data",
-        "myhero_data_key": "SecureData",
-        "myhero_app_key": "SecureApp"
-    }
+    "id": "/myhero/mosca",
+    "instances": 1,
+    "cpus": 1,
+    "mem": 64,
+    "env": {}
 }

--- a/myhero-spark.json
+++ b/myhero-spark.json
@@ -2,7 +2,7 @@
     "container": {
         "type": "DOCKER",
         "docker": {
-            "image": "hpreston/myhero_spark",
+            "image": "hpreston/myhero_spark:latest",
             "forcePullImage": true,
             "network": "BRIDGE",
             "portMappings": [{

--- a/myhero-tropo.json
+++ b/myhero-tropo.json
@@ -2,7 +2,7 @@
     "container": {
         "type": "DOCKER",
         "docker": {
-            "image": "hpreston/myhero_tropo",
+            "image": "hpreston/myhero_tropo:latest",
             "forcePullImage": true,
             "network": "BRIDGE",
             "portMappings": [{

--- a/myhero-uninstall-queue.sh
+++ b/myhero-uninstall-queue.sh
@@ -1,0 +1,28 @@
+#! /bin/bash
+
+echo Removing Web Service
+curl -k -X DELETE -u $MANTL_USER:$MANTL_PASSWORD https://$MANTL_CONTROL:8080/v2/apps/myhero/mq/web \
+-H "Content-type: application/json"
+echo
+
+echo Removing App Service
+curl -k -X DELETE -u $MANTL_USER:$MANTL_PASSWORD https://$MANTL_CONTROL:8080/v2/apps/myhero/mq/app \
+-H "Content-type: application/json"
+echo
+
+echo Removing Ernst Service
+curl -k -X DELETE -u $MANTL_USER:$MANTL_PASSWORD https://$MANTL_CONTROL:8080/v2/apps/myhero/mq/ernst \
+-H "Content-type: application/json"
+echo
+
+echo Removing Mosca
+curl -k -X DELETE -u $MANTL_USER:$MANTL_PASSWORD https://$MANTL_CONTROL:8080/v2/apps/myhero/mq/mosca \
+-H "Content-type: application/json"
+echo
+
+
+echo Removing Data Service
+curl -k -X DELETE -u $MANTL_USER:$MANTL_PASSWORD https://$MANTL_CONTROL:8080/v2/apps/myhero/mq/data \
+-H "Content-type: application/json"
+echo
+

--- a/myhero-web.json
+++ b/myhero-web.json
@@ -2,7 +2,7 @@
     "container": {
         "type": "DOCKER",
         "docker": {
-            "image": "hpreston/myhero_web",
+            "image": "hpreston/myhero_web:latest",
             "forcePullImage": true,
             "network": "BRIDGE",
             "portMappings": [{


### PR DESCRIPTION
Added a new mode for deployment that leverages an MQTT server between the APP and DATA services for vote processing.  This is intended to prevent overloading the Data service with heavy rates of voting.  This includes a new myhero_ernst service for vote processing, and leveraging the mosca MQTT broker.  
